### PR TITLE
CustomValidator return type adjusted in typescript

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -673,7 +673,7 @@ declare namespace Joi {
         message: (messages: LanguageMessages, local?: Context) => ErrorReport;
     }
 
-    type CustomValidator<V = any> = (value: V, helpers: CustomHelpers) => V;
+    type CustomValidator<V = any> = (value: V, helpers: CustomHelpers) => V | ErrorReport;
 
     type ExternalValidationFunction = (value: any) => any;
 


### PR DESCRIPTION
trying to do 
```
const xValidator: CustomValidator<string> = (value, helpers) => {
  if (!value.startsWith('x')) {
    return helpers.error('string.x')
  }
  return value
}
```
results in error
```
TS2322: Type '(value: string, helpers: CustomHelpers<any>) => string | ErrorReport' is not assignable to type 'CustomValidator<string>'.
```