### PR TITLE
Add render property to ReferenceOptions TS def

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -554,6 +554,12 @@ declare namespace Joi {
          * when true, the reference resolves by reaching into maps and sets.
          */
         iterables?: boolean;
+
+        /**
+         * when true, the value of the reference is used instead of its name in error messages 
+         * and template rendering. Defaults to false.
+         */
+        render?: boolean;
     }
 
     interface StringRegexOptions {


### PR DESCRIPTION
IDE flagged render as an invalid property today. I know this is a temporary file, but hopefully helps others in the meantime.