### PR TITLE
Add RegExp to the supported types for Extension.type

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1876,7 +1876,7 @@ declare namespace Joi {
     }
 
     interface Extension {
-        type: string;
+        type: string | RegExp;
         args?(...args: SchemaLike[]): Schema;
         base?: Schema;
         coerce?: CoerceFunction | CoerceObject;


### PR DESCRIPTION
In 03adf22eb1f06c47d1583617093edee3a96b3873, support for RegExps passed to Extension.type were introduced (e.g. `type: /^s/`). However, the types were missing that change.