### PR TITLE
Appends the allowed object keys in typescript

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1560,6 +1560,7 @@ declare namespace Joi {
          * Appends the allowed object keys. If schema is null, undefined, or {}, no changes will be applied.
          */
         append(schema?: SchemaMap<TSchema>): this;
+        append<TSchemaExtended = any, T = TSchemaExtended>(schema?: SchemaMap<T>): ObjectSchema<T>
 
         /**
          * Verifies an assertion where.


### PR DESCRIPTION
If you try to appends a strongly typed object schema
```ts
import Joi from 'joi'

type TSchema = {
  a: Joi.StringSchema
  b: Joi.NumberSchema
}

const schema = Joi.object<TSchema>({
  a: Joi.string(),
  b: Joi.number(),
})

const schemaExtended = schema.append({
  c: Joi.boolean(),
})
```

it result in error
```
Argument of type '{ a: Joi.StringSchema; b: Joi.NumberSchema; c: Joi.BooleanSchema; }' is not assignable to parameter of type 'SchemaMap<TSchema>'.
Object literal may only specify known properties, and 'c' does not exist in type 'SchemaMap<TSchema>'.
```

I suggested a commit that would make possible to do that:
```ts
import Joi from 'joi'

type TSchema = {
  a: Joi.StringSchema
  b: Joi.NumberSchema
}

type TSchemaExtended = TSchema & {
  c: Joi.BooleanSchema
}

const schema = Joi.object<TSchema>({
  a: Joi.string(),
  b: Joi.number(),
})

const schemaExtended = schema.append<TSchemaExtended>({
  c: Joi.boolean(),
})
```