### PR TITLE
fix: defaults in ordered array are not filled

### DIFF
--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -342,7 +342,13 @@ module.exports = Any.extend({
 
                 if (ordereds.length) {
                     internals.fillOrderedErrors(schema, errors, ordereds, value, state, prefs);
+
+                    if (errors.length) {
+                        return errors;
+                    }
+
                     internals.fillDefault(ordereds, value, state, prefs);
+                    return value;
                 }
 
                 return errors.length ? errors : value;

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -683,29 +683,27 @@ internals.fillOrderedErrors = function (schema, errors, ordereds, value, state, 
 
 internals.fillDefault = function (ordereds, value, state, prefs) {
 
-    const defaultValues = [];
+    const overrides = [];
     let trailingUndefined = true;
 
     for (let i = ordereds.length - 1; i >= 0; --i) {
-
-        const ancestors = [value, ...state.ancestors];
         const ordered = ordereds[i];
-        const res = ordered.$_validate(undefined, state.localize(state.path, ancestors, ordered), prefs);
-        const orderedValue = res.value;
+        const ancestors = [value, ...state.ancestors];
+        const override = ordered.$_validate(undefined, state.localize(state.path, ancestors, ordered), prefs).value;
 
         if (trailingUndefined) {
-            if (orderedValue === undefined) {
+            if (override === undefined) {
                 continue;
             }
 
             trailingUndefined = false;
         }
 
-        defaultValues.unshift(orderedValue);
+        overrides.unshift(override);
     }
 
-    if (defaultValues.length) {
-        value.push(...defaultValues);
+    if (overrides.length) {
+        value.push(...overrides);
     }
 };
 

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -342,7 +342,7 @@ module.exports = Any.extend({
 
                 if (ordereds.length) {
                     internals.fillOrderedErrors(schema, errors, ordereds, value, state, prefs);
-                    internals.fillDefaults(ordereds, value, state, prefs);
+                    internals.fillDefault(ordereds, value, state, prefs);
                 }
 
                 return errors.length ? errors : value;
@@ -678,15 +678,16 @@ internals.fillOrderedErrors = function (schema, errors, ordereds, value, state, 
 };
 
 
-internals.fillDefaults = function (ordereds, value, state, prefs) {
+internals.fillDefault = function (ordereds, value, state, prefs) {
 
     const defaultValues = [];
     let trailingUndefined = true;
 
     for (let i = ordereds.length - 1; i >= 0; --i) {
 
+        const ancestors = [value, ...state.ancestors];
         const ordered = ordereds[i];
-        const res = ordered.$_validate(undefined, state.localize(state.path, state.ancestors, ordered), prefs);
+        const res = ordered.$_validate(undefined, state.localize(state.path, ancestors, ordered), prefs);
         const orderedValue = res.value;
 
         if (trailingUndefined) {

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -664,19 +664,25 @@ internals.fillMissedErrors = function (schema, errors, requireds, value, state, 
 internals.checkRemainingOrdereds = function (schema, errors, ordereds, value, state, prefs) {
 
     const requiredOrdereds = [];
+    const orderedsWithDefault = [];
 
     for (const ordered of ordereds) {
         if (ordered._flags.presence === 'required') {
             requiredOrdereds.push(ordered);
         }
 
-        if (ordered._flags.hasOwnProperty('default')) {
-            value.push(ordered._flags.default);
+        const res = ordered.$_validate(undefined,state,prefs);
+        if (res.value !== undefined) {
+            orderedsWithDefault.push(res.value);
         }
     }
 
     if (requiredOrdereds.length) {
         internals.fillMissedErrors(schema, errors, requiredOrdereds, value, state, prefs);
+    }
+
+    if (orderedsWithDefault.length) {
+        value.push(...orderedsWithDefault);
     }
 };
 

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -341,7 +341,7 @@ module.exports = Any.extend({
                 }
 
                 if (ordereds.length) {
-                    internals.fillOrderedErrors(schema, errors, ordereds, value, state, prefs);
+                    internals.checkRemainingOrdereds(schema, errors, ordereds, value, state, prefs);
                 }
 
                 return errors.length ? errors : value;
@@ -661,13 +661,17 @@ internals.fillMissedErrors = function (schema, errors, requireds, value, state, 
 };
 
 
-internals.fillOrderedErrors = function (schema, errors, ordereds, value, state, prefs) {
+internals.checkRemainingOrdereds = function (schema, errors, ordereds, value, state, prefs) {
 
     const requiredOrdereds = [];
 
     for (const ordered of ordereds) {
         if (ordered._flags.presence === 'required') {
             requiredOrdereds.push(ordered);
+        }
+
+        if (ordered._flags.hasOwnProperty('default')) {
+            value.push(ordered._flags.default);
         }
     }
 

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -343,12 +343,9 @@ module.exports = Any.extend({
                 if (ordereds.length) {
                     internals.fillOrderedErrors(schema, errors, ordereds, value, state, prefs);
 
-                    if (errors.length) {
-                        return errors;
+                    if (!errors.length) {
+                        internals.fillDefault(ordereds, value, state, prefs);
                     }
-
-                    internals.fillDefault(ordereds, value, state, prefs);
-                    return value;
                 }
 
                 return errors.length ? errors : value;

--- a/lib/types/array.js
+++ b/lib/types/array.js
@@ -341,7 +341,8 @@ module.exports = Any.extend({
                 }
 
                 if (ordereds.length) {
-                    internals.checkRemainingOrdereds(schema, errors, ordereds, value, state, prefs);
+                    internals.fillOrderedErrors(schema, errors, ordereds, value, state, prefs);
+                    internals.fillDefaults(ordereds, value, state, prefs);
                 }
 
                 return errors.length ? errors : value;
@@ -661,28 +662,46 @@ internals.fillMissedErrors = function (schema, errors, requireds, value, state, 
 };
 
 
-internals.checkRemainingOrdereds = function (schema, errors, ordereds, value, state, prefs) {
+internals.fillOrderedErrors = function (schema, errors, ordereds, value, state, prefs) {
 
     const requiredOrdereds = [];
-    const orderedsWithDefault = [];
 
     for (const ordered of ordereds) {
         if (ordered._flags.presence === 'required') {
             requiredOrdereds.push(ordered);
-        }
-
-        const res = ordered.$_validate(undefined,state,prefs);
-        if (res.value !== undefined) {
-            orderedsWithDefault.push(res.value);
         }
     }
 
     if (requiredOrdereds.length) {
         internals.fillMissedErrors(schema, errors, requiredOrdereds, value, state, prefs);
     }
+};
 
-    if (orderedsWithDefault.length) {
-        value.push(...orderedsWithDefault);
+
+internals.fillDefaults = function (ordereds, value, state, prefs) {
+
+    const defaultValues = [];
+    let trailingUndefined = true;
+
+    for (let i = ordereds.length - 1; i >= 0; --i) {
+
+        const ordered = ordereds[i];
+        const res = ordered.$_validate(undefined, state.localize(state.path, state.ancestors, ordered), prefs);
+        const orderedValue = res.value;
+
+        if (trailingUndefined) {
+            if (orderedValue === undefined) {
+                continue;
+            }
+
+            trailingUndefined = false;
+        }
+
+        defaultValues.unshift(orderedValue);
+    }
+
+    if (defaultValues.length) {
+        value.push(...defaultValues);
     }
 };
 

--- a/package.json
+++ b/package.json
@@ -22,11 +22,11 @@
         "@sideway/pinpoint": "^2.0.0"
     },
     "devDependencies": {
-        "typescript": "4.0.x",
         "@hapi/bourne": "2.x.x",
         "@hapi/code": "8.x.x",
+        "@hapi/joi-legacy-test": "npm:@hapi/joi@15.x.x",
         "@hapi/lab": "24.x.x",
-        "@hapi/joi-legacy-test": "npm:@hapi/joi@15.x.x"
+        "typescript": "4.0.x"
     },
     "scripts": {
         "prepublishOnly": "cd browser && npm install && npm run build",

--- a/test/types/array.js
+++ b/test/types/array.js
@@ -603,15 +603,15 @@ describe('array', () => {
             ]);
         });
 
-        it('fill the defaults correctly when dynamic schema is used', () => {
+        it('fills defaults correctly when nested items contain references', () => {
 
             const schema = Joi.object({
                 info: Joi.object(),
                 values: Joi.array().ordered(
                     Joi.string().required(),
-                    Joi.string().default(Joi.ref('info.firstname')),
+                    Joi.string().default(Joi.ref('...info.firstname')),
                     Joi.string(),
-                    Joi.string().default(Joi.ref('info.lastname')),
+                    Joi.string().default(Joi.ref('...info.lastname')),
                     Joi.string()
                 ).required()
             });
@@ -622,7 +622,7 @@ describe('array', () => {
             ]);
         });
 
-        it('fill the defaults correctly when dynamic schema is used', () => {
+        it('fills defaults correctly when nested items contain references', () => {
 
             const schema = Joi.object({
                 info: Joi.object().required(),
@@ -635,7 +635,7 @@ describe('array', () => {
                         Joi.number().default(Joi.x('{number("202099")}'))
                     ),
                     Joi.string(),
-                    Joi.string().default(Joi.ref('info.firstname')),
+                    Joi.string().default(Joi.ref('...info.firstname')),
                     Joi.string()
                 ).required()
             });

--- a/test/types/array.js
+++ b/test/types/array.js
@@ -576,6 +576,15 @@ describe('array', () => {
             ]);
         });
 
+        it('can fill the default values into the value array', () => {
+
+            const schema = Joi.array().ordered( Joi.string().required(), Joi.number().default(0), Joi.number().default(6)).required();
+
+            Helper.validate(schema, [
+                [['a'], true, ['a', 0, 6]]
+            ]);
+        });
+
         it('can strip matching items', () => {
 
             const schema = Joi.array().items(Joi.string(), Joi.any().strip());


### PR DESCRIPTION
Fixes #2404 

This will ensure that, if any remaining ordered contains a default constraint, it will be pushed to the value array.

```JS
        if (ordered._flags.hasOwnProperty('default')) {
            value.push(ordered._flags.default);
        }
```

also, i changed the name of `fillOrderedErrors` method to `checkRemainingOrdereds` for clarity, since it's now not only filling errors. 