### PR TITLE
feat: Make Joi.Schema generic

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -690,7 +690,7 @@ declare namespace Joi {
         [key in keyof TSchema]?: SchemaLike | SchemaLike[];
     };
 
-    type Schema =
+    type Schema<P = any> =
         | AnySchema
         | ArraySchema
         | AlternativesSchema
@@ -699,7 +699,7 @@ declare namespace Joi {
         | DateSchema
         | FunctionSchema
         | NumberSchema
-        | ObjectSchema
+        | ObjectSchema<P>
         | StringSchema
         | LinkSchema
         | SymbolSchema;


### PR DESCRIPTION
I want to make Schema type generic in order to improve typing

- Change is seamless from a typescript point of view. It isn't breaking anything.
- Allows type inference from Joi types

Motivation comes from this issue :
https://github.com/arb/celebrate/issues/212

I know it is not directly related to Joi, but with this change it can allow any package using Joi to have better type inferences.