### PR TITLE
add subschema property validation failures to context

### DIFF
--- a/lib/types/alternatives.js
+++ b/lib/types/alternatives.js
@@ -64,7 +64,11 @@ module.exports = Any.extend({
             }
 
             if (matched.length === 0) {
-                return { errors: error('alternatives.any', Errors.details(failed.flat(), { override: false })) };
+                const context = {
+                    details: failed.map((f) => Errors.details(f, { override: false }))
+                }
+
+                return { errors: error('alternatives.any', context) };
             }
 
             if (schema._flags.match === 'one') {
@@ -72,7 +76,10 @@ module.exports = Any.extend({
             }
 
             if (matched.length !== schema.$_terms.matches.length) {
-                return { errors: error('alternatives.all', Errors.details(failed.flat(), { override: false })) };
+                const context = {
+                    details: failed.map((f) => Errors.details(f, { override: false }))
+                }
+                return { errors: error('alternatives.all', context) };
             }
 
             const allobj = schema.$_terms.matches.reduce((acc, v) => acc && v.schema.type === 'object', true);

--- a/lib/types/alternatives.js
+++ b/lib/types/alternatives.js
@@ -333,10 +333,8 @@ internals.errors = function (failures, { error, state }) {
 
 internals.unmatched = function (failures, error) {
 
-    const errors = [];
-    for (const failure of failures) {
-        errors.push(...failure.reports);
+    const context = {
+        details: failures.map((f) => Errors.details(f.reports, { override: false }))
     }
-
-    return { errors: error('alternatives.match', Errors.details(errors, { override: false })) };
+    return { errors: error('alternatives.match', context) };
 };

--- a/lib/types/alternatives.js
+++ b/lib/types/alternatives.js
@@ -46,6 +46,7 @@ module.exports = Any.extend({
 
         if (schema._flags.match) {
             const matched = [];
+            const failed = [];
 
             for (let i = 0; i < schema.$_terms.matches.length; ++i) {
                 const item = schema.$_terms.matches[i];
@@ -57,12 +58,13 @@ module.exports = Any.extend({
                     matched.push(result.value);
                 }
                 else {
+                    failed.push(result.errors)
                     localState.restore();
                 }
             }
 
             if (matched.length === 0) {
-                return { errors: error('alternatives.any') };
+                return { errors: error('alternatives.any', Errors.details(failed.flat(), { override: false })) };
             }
 
             if (schema._flags.match === 'one') {
@@ -70,7 +72,7 @@ module.exports = Any.extend({
             }
 
             if (matched.length !== schema.$_terms.matches.length) {
-                return { errors: error('alternatives.all') };
+                return { errors: error('alternatives.all', Errors.details(failed.flat(), { override: false })) };
             }
 
             const allobj = schema.$_terms.matches.reduce((acc, v) => acc && v.schema.type === 'object', true);


### PR DESCRIPTION
...during failure of `any` and `all` match modes.

Also considered adding additional context to `one` match mode, but the limit of what could be expressed without putting requirements on schema authors is likely just the index of matching schemas. e.g

`{ message: 'value matched more that one schema', context: { matchedSchemaIndexes: [0, 3, 4] } }`