### PR TITLE
Fix typos in any.allow() and object.missing

### DIFF
--- a/API.md
+++ b/API.md
@@ -4041,13 +4041,13 @@ Additional local context properties:
 
 #### `object.missing`
 
-The OR or XOR condition between the properties you specified was not satisfied in that object, none of it were set.
+The OR or XOR condition between the properties you specified was not satisfied in that object, none of them were set.
 
 Additional local context properties:
 ```ts
 {
-    peers: Array<string>, // List of properties were none of it was set
-    peersWithLabels: Array<string> // List of labels for the properties were none of it was set
+    peers: Array<string>, // List of properties where none of them were set
+    peersWithLabels: Array<string> // List of labels for the properties where none of them were set
 }
 ```
 

--- a/API.md
+++ b/API.md
@@ -918,7 +918,7 @@ const schema = Joi.any().note('this is special', 'this is important');
 
 #### `any.only()`
 
-Requires the validated value to match of the provided `any.allow()` values. It has not effect when
+Requires the validated value to match of the provided `any.allow()` values. It has no effect when
 called together with `any.valid()` since it already sets the requirements. When used with
 `any.allow()` it converts it to an `any.valid()`.
 


### PR DESCRIPTION
This fixes some typos I encountered for `any.allow()` and `object.missing`.