### PR TITLE
Feat: allow adding arguments when tailoring

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -518,7 +518,14 @@ internals.Base = class {
 
     tailor(targets) {
 
-        targets = [].concat(targets);
+        targets = typeof targets === 'string'
+          ? { [targets]: undefined }
+          : Array.isArray(targets)
+          ? Object.fromEntries(targets.map((target) => [target, undefined]))
+          : targets;
+
+        // For backwards compatibility, we do not enforce the validity of targets
+        if (!targets || typeof targets !== 'object') return this;
 
         Assert(!this._inRuleset(), 'Cannot tailor inside a ruleset');
 
@@ -526,8 +533,8 @@ internals.Base = class {
 
         if (this.$_terms.alterations) {
             for (const { target, adjuster } of this.$_terms.alterations) {
-                if (targets.includes(target)) {
-                    obj = adjuster(obj);
+                if (Object.prototype.hasOwnProperty.call(targets, target)) {
+                    obj = adjuster(obj, targets[target]);
                     Assert(Common.isSchema(obj), 'Alteration adjuster for', target, 'failed to return a schema object');
                 }
             }


### PR DESCRIPTION
This PR allows providing arguments to the adjuster function when tailoring a schema.

Example use cases:

```js
const mySchema = Joi.string().alter({
  withPattern: (schema, regexp) => schema.pattern(regexp),
});

const schemaA = mySchema.tailor({ withPattern: /a/ })
const schemaB = mySchema.tailor({ withPattern: /b/ })
```

```js
const mySchema = Joi.string().allow('foo').alter({
  withAllowedValues: (schema, additionnalAllowedValues) => schema.allow(...additionnalAllowedValues),
});

const schemaA = mySchema.tailor({ withAllowedValues: ['bar'] })
const schemaB = mySchema.tailor({ withAllowedValues: ['baz'] })
```


```js
const mySchema = Joi.string().allow('foo').alter({
  withAllowedPrefixes: (schema, allowedPrefixes) => schema.custom((value, helpers) => {
    for (const prefix of allowedPrefixes) if (value.startsWith(prefix)) return value
    return helpers.error('my-error')
  }),
});

const schemaA = mySchema.tailor({ withAllowedPrefixes: ['x.','y.'] })
```