### PR TITLE
Fix Web Workers compatibility

### DIFF
--- a/browser/package.json
+++ b/browser/package.json
@@ -10,17 +10,20 @@
         "@babel/core": "^7.4.5",
         "@babel/plugin-proposal-class-properties": "^7.7.4",
         "@babel/preset-env": "^7.4.5",
+        "assert": "^2.0.0",
         "babel-loader": "^8.0.6",
         "karma": "^4.2.0",
         "karma-chrome-launcher": "^3.0.0",
         "karma-mocha": "^1.3.0",
         "karma-sourcemap-loader": "^0.3.7",
-        "karma-webpack": "^4.0.2",
+        "karma-webpack": "^5.0.0",
         "mocha": "^6.2.0",
         "mocha-loader": "^2.0.1",
         "null-loader": "^3.0.0",
-        "webpack": "^4.35.2",
+        "process": "^0.11.10",
+        "util": "^0.12.4",
+        "webpack": "^5.40.0",
         "webpack-bundle-analyzer": "^3.4.1",
-        "webpack-cli": "^3.3.5"
+        "webpack-cli": "^4.7.2"
     }
 }

--- a/browser/webpack.config.js
+++ b/browser/webpack.config.js
@@ -57,8 +57,11 @@ module.exports = {
             }
         ]
     },
-    node: {
-        url: 'empty',
-        util: 'empty'
+    node: false,
+    resolve: {
+      fallback: {
+        url: false,
+        util: false,
+      }
     }
 };

--- a/browser/webpack.mocha.js
+++ b/browser/webpack.mocha.js
@@ -1,4 +1,5 @@
 const Path = require('path');
+const Webpack = require('webpack');
 
 const WebpackConfig = require('./webpack.config');
 
@@ -16,6 +17,14 @@ WebpackConfig.module.rules[2].use.options.presets[0][1].exclude = [
     '@babel/plugin-transform-regenerator'
 ];
 
-delete WebpackConfig.node.util;
+// Used in testing.
+WebpackConfig.plugins.push(new Webpack.ProvidePlugin({
+  process: 'process/browser',
+}));
+WebpackConfig.node = {
+  global: true,
+};
+WebpackConfig.resolve.fallback.util = require.resolve('util/');
+WebpackConfig.resolve.fallback.assert = require.resolve('assert/');
 
 module.exports = WebpackConfig;

--- a/browser/webpack.mocha.js
+++ b/browser/webpack.mocha.js
@@ -18,8 +18,8 @@ WebpackConfig.module.rules[2].use.options.presets[0][1].exclude = [
 ];
 
 // Used in testing.
-WebpackConfig.plugins.push(new Webpack.ProvidePlugin({
-  process: 'process/browser',
+WebpackConfig.plugins.push(new Webpack.DefinePlugin({
+  'process.env.NODE_DEBUG': false,
 }));
 WebpackConfig.node = {
   global: true,


### PR DESCRIPTION
Latest Webpack generated dist files no longer reference "window". Thus those
generated files are compatible with Web Workers.

Fixes https://github.com/sideway/joi/issues/2251