### PR TITLE
Fix wrong validation state href in docs

### DIFF
--- a/API.md
+++ b/API.md
@@ -3295,7 +3295,7 @@ const schema = custom.object({
 - `original`: The original value passed untouched to `validate()`.
 - `prefs`: The prepared validation options.
 - `schema`: The reference to the current schema. Useful if you need to use any of the [Advanced functions](#advanced-functions).
-- `state`: The current validation state. See [Validation state](#state)
+- `state`: The current validation state. See [Validation state](#validation-state).
 - `error`: A function with signature `function (code, local, localState = currentState) {}` similar to [`$_createError()`](#_createerrorcode-value-local-state-prefs-options) but with the current value, validation options, current state passed where:
     - `code`: The error code. 
     - `local`: Local context used to interpolate the message.


### PR DESCRIPTION
Line 3298: from `#state` to `#validation-state`
Line 3298: add a full stop