### PR TITLE
fix: Joi.string().hostname() not returning errors for CIDR notation

### DIFF
--- a/lib/types/string.js
+++ b/lib/types/string.js
@@ -28,7 +28,7 @@ const internals = {
     },
     dataUriRegex: /^data:[\w+.-]+\/[\w+.-]+;((charset=[\w-]+|base64),)?(.*)$/,
     hexRegex: /^[a-f0-9]+$/i,
-    ipRegex: Ip.regex().regex,
+    ipRegex: Ip.regex({ cidr: 'forbidden' }).regex,
     isoDurationRegex: /^P(?!$)(\d+Y)?(\d+M)?(\d+W)?(\d+D)?(T(?=\d)(\d+H)?(\d+M)?(\d+S)?)?$/,
 
     guidBrackets: {

--- a/test/types/string.js
+++ b/test/types/string.js
@@ -4211,6 +4211,18 @@ describe('string', () => {
                     path: [],
                     type: 'string.hostname',
                     context: { value: '0:?:0:0:0:0:0:1', label: 'value' }
+                }],
+                ['10.10.10.10/24', false, {
+                    message: '"value" must be a valid hostname',
+                    path: [],
+                    type: 'string.hostname',
+                    context: { value: '10.10.10.10/24', label: 'value' }
+                }],
+                ['2001:db8::/48', false, {
+                    message: '"value" must be a valid hostname',
+                    path: [],
+                    type: 'string.hostname',
+                    context: { value: '2001:db8::/48', label: 'value' }
                 }]
             ]);
         });


### PR DESCRIPTION
Fixes #2648