### PR TITLE
Fix label elimination for externals

### DIFF
--- a/lib/validator.js
+++ b/lib/validator.js
@@ -94,7 +94,10 @@ exports.entryAsync = async function (value, schema, prefs) {
                 }
             }
             catch (err) {
-                err.message += ` (${label})`;       // Change message to include path
+                if (settings.errors.label) {
+                    err.message += ` (${label})`;       // Change message to include path
+                }
+
                 throw err;
             }
         }

--- a/test/validator.js
+++ b/test/validator.js
@@ -405,6 +405,22 @@ describe('Validator', () => {
             const result = await schema.validateAsync(input, { context });
             expect(result).to.equal('bar');
         });
+
+        it('changes the message depending on label\'s value', async () => {
+
+            const context = { foo: 'bar' };
+
+            const tag = (value, { prefs }) => {
+
+                throw new Error('Oops');
+            };
+
+            const schema = Joi.string().external(tag);
+            const input = 'my string';
+
+            await expect(schema.validateAsync(input, { context })).to.reject('Oops (value)');
+            await expect(schema.validateAsync(input, { context, errors: { label: false } })).to.reject('Oops');
+        });
     });
 
     describe('finalize()', () => {


### PR DESCRIPTION
Fixes #2600
Fixes #2635

I'm not convinced it's such a good thing to add the label to the error message when users have full control over the error, shouldn't we leave this error alone no matter what the settings say?