### PR TITLE
Fix typings on any.external(): add helpers argument

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -681,7 +681,11 @@ declare namespace Joi {
 
     type CustomValidator<V = any> = (value: V, helpers: CustomHelpers) => V | ErrorReport;
 
-    type ExternalValidationFunction = (value: any) => any;
+    interface ExternalHelpers {
+        prefs: ValidationOptions;
+    }
+
+    type ExternalValidationFunction<V = any> = (value: V, helpers: ExternalHelpers) => V | undefined;
 
     type SchemaLikeWithoutArray = string | number | boolean | null | Schema | SchemaMap;
     type SchemaLike = SchemaLikeWithoutArray | object;


### PR DESCRIPTION
Since #2455 `prefs` are passed to `external` validation as second argument. However, typings had not been updated.

This pr fixes typings for external validation.

Closes #2605