### PR TITLE
Updated `multiple` rule to support decimal/float base

### DIFF
--- a/lib/types/number.js
+++ b/lib/types/number.js
@@ -169,7 +169,7 @@ module.exports = Any.extend({
             },
             validate(value, helpers, { base }, options) {
 
-                if (value % base === 0) {
+                if (value * (1 / base) % 1 === 0) {
                     return value;
                 }
 


### PR DESCRIPTION
Updated `multiple` rule with a better use of the remainder (`%`) operator to support decimal/float base

[Demo](https://codepen.io/MathijsvVelde/pen/MWowBZe?editors=0012)