### PR TITLE
Add Date -> Joi.DateSchema map to ObjectPropertiesSchema<T>

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -697,6 +697,8 @@ declare namespace Joi {
         ? Joi.NumberSchema
         : T extends NullableType<boolean>
         ? Joi.BooleanSchema
+        : T extends NullableType<Date>
+        ? Joi.DateSchema
         : T extends NullableType<Array<any>>
         ? Joi.ArraySchema
         : T extends NullableType<object>


### PR DESCRIPTION
Handle mapping of `DateSchema` validation types to Date when using `StrictSchemaValidation<T>`

For example:

```
type MyApi = {
   foo: string;
   bar: Date;
}

const schema = Joi.object<MyApi>({
Joi.object({
    foo: Joi.string(),
   // this is a typescript error in current codebase
    bar: Joi.date(),
}
```

