### PR TITLE
issue #2606: pass TSchema from ObjectSchema to .validate function

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -642,10 +642,14 @@ declare namespace Joi {
 
     type ValidationErrorFunction = (errors: ErrorReport[]) => string | ValidationErrorItem | Error;
 
-    interface ValidationResult {
-        error?: ValidationError;
+    type ValidationResult<TSchema = any> = {
+        error: undefined;
         warning?: ValidationError;
-        value: any;
+        value: TSchema;
+    } | {
+        error: ValidationError;
+        warning?: ValidationError;
+        value: undefined;
     }
 
     interface CreateErrorOptions {
@@ -828,7 +832,7 @@ declare namespace Joi {
         $_validate(value: any, state: State, prefs: ValidationOptions): ValidationResult;
     }
 
-    interface AnySchema extends SchemaInternals {
+    interface AnySchema<TSchema = any> extends SchemaInternals {
         /**
          * Flags of current schema.
          */
@@ -1151,7 +1155,7 @@ declare namespace Joi {
         /**
          * Validates a value using the schema and options.
          */
-        validate(value: any, options?: ValidationOptions): ValidationResult;
+        validate(value: any, options?: ValidationOptions): ValidationResult<TSchema>;
 
         /**
          * Validates a value using the schema and options.
@@ -1571,7 +1575,7 @@ declare namespace Joi {
         matches: SchemaLike | Reference;
     }
 
-    interface ObjectSchema<TSchema = any> extends AnySchema {
+    interface ObjectSchema<TSchema = any> extends AnySchema<TSchema> {
         /**
          * Defines an all-or-nothing relationship between keys where if one of the peers is present, all of them are required as well.
          *


### PR DESCRIPTION
improves typings for the `.validate` function so that if a type is passed when calling `.object()` it also makes its way to `.validate().value`