### PR TITLE
Fix typings for any.external

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -680,8 +680,12 @@ declare namespace Joi {
     }
 
     type CustomValidator<V = any> = (value: V, helpers: CustomHelpers) => V | ErrorReport;
+    
+    interface ExternalValidationHelpers {
+        prefs: ValidationOptions;
+    }
 
-    type ExternalValidationFunction = (value: any) => any;
+    type ExternalValidationFunction<V = any> = (value: V, helpers: ExternalValidationHelpers) => V | Promise<V>;
 
     type SchemaLikeWithoutArray = string | number | boolean | null | Schema | SchemaMap;
     type SchemaLike = SchemaLikeWithoutArray | object;


### PR DESCRIPTION
According to the documentation, the `external` function should receive a method with both `value` and `helpers` as parameters.
The documentation also states that the function can both by `sync` or `async`

https://joi.dev/api/?v=17.4.2#anyexternalmethod-description.

