### PR TITLE
Fix typos in API.md ('Names links' -> 'Named links', 'unknownMisees' -> 'unknownMisses')

### DIFF
--- a/API.md
+++ b/API.md
@@ -1999,7 +1999,7 @@ Supports the methods of the [`any()`](#any) type.
 
 When links are combined with `any.when()` rules, the rules are applied after the link is resolved to the linked schema.
 
-Names links are recommended for most use cases as they are easy to reason and understand, and when mistakes are made, they simply error with invalid link message. Relative links are often hard to follow, especially when they are nested in array or alternatives rules. Absolute links are useful only when the schema is never reused inside another schema as the root is the run-time root of the schema being validated, not the current schema root.
+Named links are recommended for most use cases as they are easy to reason and understand, and when mistakes are made, they simply error with invalid link message. Relative links are often hard to follow, especially when they are nested in array or alternatives rules. Absolute links are useful only when the schema is never reused inside another schema as the root is the run-time root of the schema being validated, not the current schema root.
 
 Note that named links must be found in a direct ancestor of the link. The names are searched by iterating over the chain of schemas from the current schema to the root. To reach an uncle or cousin, you must use the name of a common ancestor such as a grandparent and then walk down the tree.
 
@@ -3582,7 +3582,7 @@ Additional local context properties:
 ```ts
 {
     knownMisses: Array<string>, // Labels of all the missing values
-    unknownMisees: number // Count of missing values that didn't have a label
+    unknownMisses: number // Count of missing values that didn't have a label
 }
 ```
 
@@ -3604,7 +3604,7 @@ Some values were expected to be present in the array and are missing. This error
 Additional local context properties:
 ```ts
 {
-    unknownMisees: number // Count of missing values that didn't have a label
+    unknownMisses: number // Count of missing values that didn't have a label
 }
 ```
 


### PR DESCRIPTION

This PR corrects 3 typos in the [API docs](https://github.com/sideway/joi/blob/master/API.md), as follows:

***

### 1. [link(ref)](https://joi.dev/api/?v=17.5.0#linkref)

"Names links are recommended for most use cases"

-->

"Named links are recommended for most use cases"

***

### 2. [array.includesRequiredBoth](https://joi.dev/api/?v=17.5.0#arrayincludesrequiredboth)

```
{
    knownMisses: Array<string>, // Labels of all the missing values
    unknownMisees: number // Count of missing values that didn't have a label
}
```

-->

```
{
    knownMisses: Array<string>, // Labels of all the missing values
    unknownMisses: number // Count of missing values that didn't have a label
}
```

***

### 3. [array.includesRequiredUnknowns](https://joi.dev/api/?v=17.5.0#arrayincludesrequiredunknowns)

```
{
    unknownMisees: number // Count of missing values that didn't have a label
}
```

-->

```
{
    unknownMisses: number // Count of missing values that didn't have a label
}
```