### PR TITLE
Better unknown handling configuration

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -30,6 +30,8 @@ declare namespace Joi {
 
     type PresenceMode = 'optional' | 'required' | 'forbidden';
 
+    type AllowMode = boolean | 'allowed' | 'forbidden' | 'warn';
+
     interface ErrorFormattingOptions {
         /**
          * when true, error message templates will escape special characters to HTML entities, for security purposes.
@@ -104,7 +106,10 @@ declare namespace Joi {
          *
          * @default false
          */
-        allowUnknown?: boolean;
+        allowUnknown?: AllowMode | {
+            mode: AllowMode,
+            type?: string,
+        };
         /**
          * when true, schema caching is enabled (for schemas with explicit caching rules).
          *

--- a/lib/types/keys.js
+++ b/lib/types/keys.js
@@ -975,16 +975,28 @@ internals.unknown = function (schema, value, unprocessed, errors, state, prefs) 
         }
     }
 
-    const forbidUnknown = !Common.default(schema._flags.unknown, prefs.allowUnknown);
-    if (forbidUnknown) {
+    const allowUnknown = Common.default(schema._flags.unknown, prefs.allowUnknown);
+    const allowUnknownIsObject = typeof allowUnknown === 'object' && !Array.isArray(allowUnknown) && allowUnknown !== null;
+    const type = (allowUnknownIsObject ? allowUnknown.type : undefined) || 'object.unknown';
+
+    if (allowUnknown === false || allowUnknown === undefined || allowUnknown === 'forbidden' || (allowUnknownIsObject && allowUnknown.mode === 'forbidden')) {
         for (const unprocessedKey of unprocessed) {
             const localState = state.localize([...state.path, unprocessedKey], []);
-            const report = schema.$_createError('object.unknown', value[unprocessedKey], { child: unprocessedKey }, localState, prefs, { flags: false });
+            const report = schema.$_createError(type, value[unprocessedKey], { child: unprocessedKey }, localState, prefs, { flags: false });
             if (prefs.abortEarly) {
                 return { value, errors: report };
             }
 
             errors.push(report);
+        }
+    }
+    else if (allowUnknown === 'warn' || (allowUnknownIsObject && allowUnknown.mode === 'warn')) {
+
+        for (const unprocessedKey of unprocessed) {
+            const localState = state.localize([...state.path, unprocessedKey], []);
+            const report = schema.$_createError(type, value[unprocessedKey], { child: unprocessedKey }, localState, prefs, { flags: false });
+
+            state.mainstay.warnings.push(report);
         }
     }
 };

--- a/test/validator.js
+++ b/test/validator.js
@@ -508,6 +508,47 @@ describe('Validator', () => {
                 }
             });
         });
+
+        it('reports warnings with nested options', () => {
+
+            const schema = Joi.object({
+                nested: Joi.object({
+                    validKey: Joi.string()
+                })
+            }).warning('custom.x').message('test');
+
+            const allowUnknown = {
+                mode: 'warn',
+                type: 'custom.x'
+            };
+
+            const input = {
+                nested: {
+                    validKey: 'some string',
+                    invalidKey: 'oh no!'
+                }
+            };
+
+            const { value, error, warning } = schema.validate(input, { allowUnknown });
+            expect(value).to.equal(input);
+            expect(error).to.not.exist();
+            expect(warning).to.equal({
+                message: 'test',
+                details: [
+                    {
+                        message: 'test',
+                        path: ['nested', 'invalidKey'],
+                        type: 'custom.x',
+                        context: {
+                            child: 'invalidKey',
+                            key: 'invalidKey',
+                            label: 'nested.invalidKey',
+                            value: 'oh no!'
+                        }
+                    }
+                ]
+            });
+        });
     });
 
     describe('Shadow', () => {


### PR DESCRIPTION
Fixes #2739

Status: Draft
This is still a draft as I haven't been able to dedicate the time required to fix up the tests. I'm open to someone else helping out and/or providing guidance. 😄 


This PR aims to have better handling of unknown keys. Within the `validate` configuration, instead of just a `boolean`, `allowUknown` supports clearer definitions:
```
type AllowMode = boolean | 'allowed' | 'forbidden' | 'warn';
...

allowUnknown?: AllowMode | {
    mode: AllowMode,
    type?: string,
};
```

These means we can either allow unknown keys with `allowed` or `true`, reject with `forbidden` or `false`, or warn with `warn`. If `warn` or `forbidden` are set, we can set what type the warning or error object are by setting the `type` property.