### PR TITLE
fix(typings): validateAsync should return a typed promise

### DIFF
--- a/lib/index.d.ts
+++ b/lib/index.d.ts
@@ -1185,7 +1185,7 @@ declare namespace Joi {
         /**
          * Validates a value using the schema and options.
          */
-        validateAsync(value: any, options?: AsyncValidationOptions): Promise<any>;
+        validateAsync(value: any, options?: AsyncValidationOptions): Promise<TSchema>;
 
         /**
          * Same as `rule({ warn: true })`.


### PR DESCRIPTION
Unlike `validate`, `validateAsync` does not return a properly typed promise.

This change fixes that.